### PR TITLE
Fix up full-page scrolling layout with fixed header for about page

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -6,7 +6,6 @@
 
     <title>Heatmap</title>
     <link rel="stylesheet" href="../styles.css" />
-    <link rel="stylesheet" href="../loader.css" />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.15.0/cdn/themes/light.css"

--- a/styles.css
+++ b/styles.css
@@ -28,7 +28,6 @@ body {
 
 .navbar {
   display: inline;
-  position: fixed; /* disabling this causes issues in the About page */
   top: 0;
   left: 0;
   padding: 10px 20px;
@@ -94,9 +93,16 @@ label[for="toggle-unicode"] {
 
 .about-main-container {
   display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  height: 100vh;
 }
+
+.about-main-container main {
+  overflow-y: scroll;
+}
+
 .about-title {
-  padding: 20px;
   text-align: center;
 }
 
@@ -155,16 +161,6 @@ label[for="toggle-unicode"] {
   flex-direction: column;
   height: 100vh;
   overflow: hidden;
-}
-
-.about-title {
-  padding: 20px;
-  text-align: center;
-}
-
-.about-body {
-  padding: 20px;
-  text-align: center;
 }
 
 .container {


### PR DESCRIPTION
This PR reorganzies the full-page layout for the about page so that the header is fixed but the rest scrolls appropriately (without layout shift when the `<details/>` accordions are opened and closed).

(The best solution for this kind of thing is to use a full-height flexbox with `flex-direction: column`, and to force the scrollbar using `overflow-y: scroll` so that the horizontal space is reserved even when the scrollbar isn't needed -- this way there's no left/right shift when one suddenly *is* needed.)

(`position: fixed` is probably best used very sparingly or not at all -- it can cause all kinds of other problems, partly because it removes the element from the document layout flow, as you've seen in #10.)

Closes #10.